### PR TITLE
feat(cli): add --name flag to personalize greeting

### DIFF
--- a/__tests__/hello.test.js
+++ b/__tests__/hello.test.js
@@ -40,6 +40,27 @@ describe('hello CLI', () => {
     expect(exitCode).toBe(0);
   });
 
+  test('--name personalizes the greeting', async () => {
+    const { stdout, stderr, exitCode } = await run(['--name', 'Alice']);
+    expect(stdout).toBe('Hello, Alice!');
+    expect(stderr).toBe('');
+    expect(exitCode).toBe(0);
+  });
+
+  test('-n short form personalizes the greeting', async () => {
+    const { stdout, stderr, exitCode } = await run(['-n', 'Alice']);
+    expect(stdout).toBe('Hello, Alice!');
+    expect(stderr).toBe('');
+    expect(exitCode).toBe(0);
+  });
+
+  test('--name without value prints error and exits 1', async () => {
+    const { stdout, stderr, exitCode } = await run(['--name']);
+    expect(stderr).toContain('Missing value for --name');
+    expect(stdout).toBe('');
+    expect(exitCode).toBe(1);
+  });
+
   test('unknown flag prints error to stderr and exits 1', async () => {
     const { stdout, stderr, exitCode } = await run(['--foo']);
     expect(stderr).toContain('Unknown option: --foo');

--- a/bin/hello.js
+++ b/bin/hello.js
@@ -10,13 +10,25 @@ if (args.includes('--help') || args.includes('-h')) {
   console.log(`Usage: hello [options]
 
 Options:
-  -h, --help     Show this help message
-  -v, --version  Show version number`);
+  -n, --name <name>  Personalize the greeting
+  -h, --help         Show this help message
+  -v, --version      Show version number`);
   process.exit(0);
 }
 
 if (args.includes('--version') || args.includes('-v')) {
   console.log(pkg.version);
+  process.exit(0);
+}
+
+const nameIndex = args.findIndex((a) => a === '--name' || a === '-n');
+if (nameIndex !== -1) {
+  const name = args[nameIndex + 1];
+  if (!name) {
+    console.error('Missing value for --name');
+    process.exit(1);
+  }
+  console.log(`Hello, ${name}!`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
Add `--name`/`-n` flag that personalizes the greeting output, e.g. `hello --name Alice` prints "Hello, Alice!".

## Changes
- Add `--name`/`-n <name>` argument parsing to `bin/hello.js`
- Print error and exit 1 when `--name` is provided without a value
- Update `--help` output to document the new flag
- Add 3 integration tests covering `--name`, `-n`, and missing value

## Test Plan
- [x] All guardrails pass
- [x] `npm test` — 7/7 tests pass
- [x] `npx eslint .` — clean
- [x] `npx prettier --check .` — clean

Closes #9

---
Agent: matt-sergi/agent-1